### PR TITLE
feat: don't override spread props by alias - in case the aliased prop is before spread

### DIFF
--- a/src/__tests__/__snapshots__/environments.test.js.snap
+++ b/src/__tests__/__snapshots__/environments.test.js.snap
@@ -3,7 +3,7 @@
 exports[`environment should alias testId prop when ALIAS_ENVIRONMENT=QA 1`] = `
 "React.createClass({
   render: function () {
-    return <div className=\\"bar\\" testID=\\"appiumSelector\\" accessibilityLabel=\\"appiumSelector\\" accessibilityContent=\\"appiumSelector\\">
+    return <div className=\\"bar\\" testID=\\"appiumSelector\\" accessibilityContent=\\"appiumSelector\\" accessibilityLabel=\\"appiumSelector\\">
     Hello Wold!
     </div>;
   }

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -13,7 +13,7 @@ exports[`fixtures should work with alias 1`] = `
 exports[`fixtures should work with class 1`] = `
 "class MyComponent extends React.Component {
   render() {
-    return <div testID=\\"foo\\" accessibilityLabel=\\"foo\\" accessibilityContent=\\"foo\\" />;
+    return <div testID=\\"foo\\" accessibilityContent=\\"foo\\" accessibilityLabel=\\"foo\\" />;
   }
 
 }"
@@ -24,12 +24,12 @@ exports[`fixtures should work with complex 1`] = `
   render: function ({
     testID
   }) {
-    return <button testID={testID} foo=\\"foo\\" accessibilityLabel={testID} accessibilityContent={testID} bar=\\"foo\\" />;
+    return <button testID={testID} accessibilityContent={testID} accessibilityLabel={testID} foo=\\"foo\\" bar=\\"foo\\" />;
   }
 });
 React.createClass({
   render: function () {
-    return <Foo testID=\\"bar\\" accessibilityLabel=\\"bar\\" accessibilityContent=\\"bar\\" />;
+    return <Foo testID=\\"bar\\" accessibilityContent=\\"bar\\" accessibilityLabel=\\"bar\\" />;
   }
 });"
 `;
@@ -47,9 +47,10 @@ exports[`fixtures should work with noop 1`] = `
 exports[`fixtures should work with spread 1`] = `
 "const Button = React.createClass({
   render: function ({
-    testID
+    testID,
+    objToSpread
   }) {
-    return <button testID={testID} accessibilityLabel={testID} />;
+    return <button testID={testID} accessibilityLabel={testID} {...objToSpread} />;
   }
 });
 const Main = React.createClass({

--- a/src/__tests__/fixtures/spread/actual.js
+++ b/src/__tests__/fixtures/spread/actual.js
@@ -1,6 +1,6 @@
 const Button = React.createClass({
-  render: function ({ testID }) {
-    return (<button testID={testID} />)
+  render: function ({ testID, objToSpread }) {
+    return (<button testID={testID} {...objToSpread} />)
   }
 });
 


### PR DESCRIPTION
In many cases it is not appropriate to override existing spread props - especially when the source prop does not do that.
Example:
```
(props) => <a testID='link' {...props} />
```
Expected
```
(props) => <a testID='link'  aliased='link' {...props}/>
```
Actual (before this PR)
```
(props) => <a testID='link' {...props} aliased='link'/>
```
Similar issue as in https://github.com/shawnxusy/babel-plugin-react-generate-property/issues/11

Note that in case it is actually intended to overwrite the spread props, the developer can write something like:
```
(props) => <a  {...props} testID='link' />
```


